### PR TITLE
超简易侧边栏广告

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -130,6 +130,10 @@ function themeConfig($form) {
     $announcement = new Typecho_Widget_Helper_Form_Element_Textarea('announcement', NULL, _t('这里是公告<br>'), _t('公告'), _t('在这里填入公告，它会显示在右侧栏的公告上,采用html写法'));
     $form->addInput($announcement);
     
+    $AD = new Typecho_Widget_Helper_Form_Element_Textarea('AD', NULL, _t('暂无广告<br>'), _t('广告'), _t('在这里填入广告，会显示在侧栏中公告栏的下方，支持html'));
+    $form->addInput($AD);
+	
+	
     $headerimg = new Typecho_Widget_Helper_Form_Element_Text('headerimg', NULL,_t('https://tva1.sinaimg.cn/large/007X0Rdyly1ghm1qiihrdj31hc0u07jk.jpg'), _t('主页顶图(banner image)'), _t('填入主页头图链接'));
     $form->addInput($headerimg);
     

--- a/post_sidebar.php
+++ b/post_sidebar.php
@@ -49,6 +49,9 @@
     <div class="card-widget card-announcement"><div class="item-headline">
         <i class="fas fa-bullhorn card-announcement-animation"></i><span>公告</span></div>
     <div class="announcement_content"><?php $this->options->announcement() ?></div></div>
+	<div class="card-widget card-announcement"><div class="item-headline">
+        <i class="fas fa-bullhorn card-announcement-animation"></i><span>广告</span></div>
+    <div class="announcement_content"><?php $this->options->AD() ?></div></div>
 <div class="sticky_layout">
     <div class="card-widget" id="card-toc">
   <div class="item-headline">

--- a/sidebar.php
+++ b/sidebar.php
@@ -51,6 +51,9 @@
         <i class="fas fa-bullhorn card-announcement-animation"></i><span>公告</span></div>
     <div class="announcement_content"><?php $this->options->announcement() ?></div></div>
     <?php endif; ?>
+	<div class="card-widget card-announcement"><div class="item-headline">
+        <i class="fas fa-bullhorn card-announcement-animation"></i><span>广告</span></div>
+    <div class="announcement_content"><?php $this->options->AD() ?></div></div>
     <div class="sticky_layout">
     <?php if (!empty($this->options->sidebarBlock) && in_array('ShowRecentPosts', $this->options->sidebarBlock)): ?>
     <div class="card-widget card-recent-post">


### PR DESCRIPTION
在公告栏下方加入了广告栏，用的是主题自带的样式，支持html代码。