### PR TITLE
修bug：开启自定义颜色以后所有页面字体变大

### DIFF
--- a/header_com.php
+++ b/header_com.php
@@ -329,7 +329,6 @@ var GLOBAL_CONFIG_SITE = {
     background-color: <?php $this->options->CustomColorMain()?>!important;
 }
 :root {
-    --global-font-size: 25px!important;
     --btn-hover-color: <?php $this->options->CustomColorButtonHover()?>;
     --btn-bg: <?php $this->options->CustomColorButtonBG()?>;
     --text-bg-hover: <?php $this->options->CustomColorButtonBG()?>;


### PR DESCRIPTION
删掉这行强制设置字体大小的css