### PR TITLE
修复首页Plugin类找不到

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,5 +1,4 @@
 <?php
-use Typecho\Plugin;
 if (!defined('__TYPECHO_ROOT_DIR__'))
     exit;
 
@@ -1501,7 +1500,7 @@ function getSiteStatistics()
 
 function getThemeVersion()
 {
-  $version = Plugin::parseInfo(Helper::options()->themeFile(Helper::options()->theme, "index.php"))["version"];
+  $version = Typecho_Plugin::parseInfo(Helper::options()->themeFile(Helper::options()->theme, "index.php"))["version"];
   return $version;
 }
 


### PR DESCRIPTION
修复首页Class 'Typecho\Plugin' not found

<img width="1202" height="396" alt="image" src="https://github.com/user-attachments/assets/698812d1-4f8e-449e-9d99-22ff4612a56a" />
