### PR TITLE
fix(theme): 修复“跟随系统”模式首次加载不适配问题与潜在的 JS 崩溃风险

### DIFF
--- a/includes/header_com.php
+++ b/includes/header_com.php
@@ -290,22 +290,48 @@
       e.activateLightMode = () => {
         document.documentElement.setAttribute("data-theme", "light"), null !== document.querySelector('meta[name="theme-color"]') && document.querySelector('meta[name="theme-color"]').setAttribute("content", "#ffffff")
       };
-      const t = saveToLocal.get("theme"),
-        a = <?php $this->options->darkModeSelect() ?> === 4,
-        o = <?php $this->options->darkModeSelect() ?> === 1,
-        c = <?php $this->options->darkModeSelect() ?> === 2,
-        n = !a && !o && !c;
+      const t = saveToLocal.get("theme");
+      
+      // 1. 将 PHP 输出包裹在引号中并转为整数，防止后台配置为空时 JS 语法报错崩溃
+      const darkModeSetting = parseInt('<?php $this->options->darkModeSelect() ?>', 10);
+      
+      // 2. 统一判断模式
+      const isDarkMode = darkModeSetting === 4,
+            isLightMode = darkModeSetting === 1,
+            isSystemMode = darkModeSetting === 2,
+            isTimeMode = !isDarkMode && !isLightMode && !isSystemMode;
+      
       if (void 0 === t) {
-        if (o) activateLightMode();
-        else if (a) activateDarkMode();
-        else if (n) {
-          const e = (new Date).getHours();
-          <?php darkTimeFunc() ?> ? activateDarkMode() : activateLightMode()
+        if (isLightMode) {
+          activateLightMode();
+        } 
+        else if (isDarkMode) {
+          activateDarkMode();
+        } 
+        else if (isSystemMode) {
+          // 跟随系统模式
+          const media = window.matchMedia("(prefers-color-scheme: dark)");
+          media.matches ? activateDarkMode() : activateLightMode();
+      
+          // 【重要修复】只在“跟随系统”模式下，才注册系统主题切换监听器
+          media.addEventListener("change", e => {
+            if (void 0 === saveToLocal.get("theme")) {
+              e.matches ? activateDarkMode() : activateLightMode();
+            }
+          });
+        } 
+        else if (isTimeMode) {
+          // 时间段控制：改用 if 判断更具容错性
+          if (<?php darkTimeFunc() ?>) {
+            activateDarkMode();
+          } else {
+            activateLightMode();
+          }
         }
-        window.matchMedia("(prefers-color-scheme: dark)").addListener((e => {
-          void 0 === saveToLocal.get("theme") && (e.matches ? activateDarkMode() : activateLightMode())
-        }))
-      } else "light" === t ? activateLightMode() : activateDarkMode();
+      } else {
+        // 用户手动切换过，以本地缓存为准
+        "light" === t ? activateLightMode() : activateDarkMode();
+      }
       const d = saveToLocal.get("aside-status");
       void 0 !== d && ("hide" === d ? document.documentElement.classList.add("hide-aside") : document.documentElement.classList.remove("hide-aside"));
       /iPad|iPhone|iPod|Macintosh/.test(navigator.userAgent) && document.documentElement.classList.add("apple")


### PR DESCRIPTION
## 存在的问题 (Problem)
系统随动缺陷：原夜间模式切换逻辑中，系统主题监听器（EventListener）生命周期管理不当。导致在用户首次打开网页（本地无缓存）时，网页无法根据系统当前的深浅色状态进行初始化适配（冷启动失效），只有在页面加载完毕后，用户去手动切换系统的深浅色模式，网页才会跟随变化。

## 解决方案 (Solution)
对齐系统随动逻辑：
- 在 isSystemMode 模式分支下，首先通过 window.matchMedia().matches 进行静态初始化，确保首次载入页面时立即精准对齐系统颜色。
- 将 media.addEventListener("change") 动态监听器严格限制在 isSystemMode 分支内部注册，避免在无缓存状态下误干扰时间段控制、强制单色等其他既定模式。

## 增强前端容错安全性：

使用单引号 '<?php ... ?>' 包裹 PHP 的配置输出，并配合 parseInt(..., 10) 进行类型收敛。即使后台配置项为空，也会安全地转换为 NaN 并回退到默认模式，绝对不会引发前端 JS 语法崩溃。

## 提升代码可读性与维护性：

将原本晦涩的单字母变量（a, o, c, n）重构为具有明确语义的布尔标志（isDarkMode, isLightMode, isSystemMode, isTimeMode）。

## 变更类型 (Type of Change)
[x] Bug 修复 (Bug fix)
[x] 代码重构/优化 (Refactor)

## 测试验证 (Verification)
- 冷启动测试：
清除浏览器本地缓存，分别在系统深色/浅色模式下刷新网页，网页均能在首次载入时瞬间精准适配，不再有滞后或不响应的现象。
- 动态随动测试：
保持页面打开，切换系统外观，网页可以实时、流畅地完成日夜间模式随动切换。

## 测试平台：
Macos 15.2 (x86_64)
Chrome 149.0.7827.156 (x86_64)
Safari 18.2 (x86_64)