### PR TITLE
feat: add Gravatar and QQ avatar support for author profile

### DIFF
--- a/config/custom_config.php
+++ b/config/custom_config.php
@@ -470,6 +470,26 @@ function themeConfig($form)
     $logoUrl = new Typecho_Widget_Helper_Form_Element_Text('logoUrl', NULL, _t('#null'), _t('作者头像'), _t('在这里填入图片地址，它会显示在右侧栏的作者头像'));
     $form->addInput($logoUrl);
 
+    $authorGravatarEmail = new Typecho_Widget_Helper_Form_Element_Text(
+            'authorGravatarEmail', 
+            NULL, 
+            NULL, 
+            _t('作者Gravatar邮箱'), 
+            _t('当头像模式选择为【使用Gravatar】时生效。填入你的Gravatar注册邮箱（如果是QQ邮箱会自动调用QQ头像）。')
+        );
+    $form->addInput($authorGravatarEmail);
+
+    $LogoAvatarMode = new Typecho_Widget_Helper_Form_Element_Radio(
+        'LogoAvatarMode',
+        [
+            'url' => '使用自定义头像URL',
+            'gravatar' => '使用Gravatar'
+        ],
+        'url',
+        _t('作者头像模式')
+    );
+    $form->addInput($LogoAvatarMode);
+
     $author_description = new Typecho_Widget_Helper_Form_Element_Text('author_description', NULL, _t('作者描述'), _t('作者描述'), _t('在这里填入站点描述，它会显示在右侧栏的作者信息'));
     $form->addInput($author_description);
 

--- a/functions.php
+++ b/functions.php
@@ -1659,6 +1659,34 @@ function getGravatar($email, $name, $comments_a, $s = 96, $d = 'mp', $r = 'g')
     return $imga;
 }
 
+// 获取作者头像URL (融合自定义URL与Gravatar逻辑)
+function getAuthorAvatarUrl() {
+    $options = Helper::options();
+    $mode = $options->LogoAvatarMode;
+    
+    // 如果选择 Gravatar 模式且填写了邮箱
+    if ($mode == 'gravatar' && !empty($options->authorGravatarEmail)) {
+        $email = $options->authorGravatarEmail;
+        $hash = md5(strtolower(trim($email)));
+        
+        // 匹配是否为 QQ 邮箱
+        preg_match_all('/((\d)*)@qq.com/', $email, $vai);
+        if (empty($vai['1']['0'])) {
+            // 普通邮箱，调用后台选择的源
+            $cdn = $options->GravatarSelect;
+        } else {
+            // QQ邮箱，按照你评论区的逻辑，直接强制使用 cravatar 或者是对应的QQ源
+            $cdn = 'https://cravatar.cn/avatar/';
+        }
+        
+        // 返回拼接好的链接，s=200 设置图片大小更清晰
+        return $cdn . $hash . '?s=200';
+    } 
+    
+    // 默认或未填邮箱时，返回自定义URL
+    return $options->logoUrl;
+}
+
 // 获取浏览器信息
 function getBrowser($agent)
 {

--- a/includes/header_com.php
+++ b/includes/header_com.php
@@ -465,7 +465,7 @@
     <div id="menu-mask" style="display: none;"></div>
     <div id="sidebar-menus" class="">
       <div class="avatar-img is-center">
-        <img src="<?php $this->options->logoUrl() ?>" onerror="this.onerror=null;this.src='https://<?php $this->options->jsdelivrLink() ?>/npm/hexo-butterfly@1.0.0/themes/butterfly/source/img/friend_404.gif'" alt="avatar">
+        <img src="<?php echo getAuthorAvatarUrl(); ?>" onerror="this.onerror=null;this.src='https://<?php $this->options->jsdelivrLink() ?>/npm/hexo-butterfly@1.0.0/themes/butterfly/source/img/friend_404.gif'" alt="avatar">
       </div>
       <div class="site-data">
         <div class="card-info-data site-data is-center">

--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -9,7 +9,7 @@ $showToc = ($isSingleSidebar && !$disableToc) ? getThemeFieldValue($this->cid, '
     <div class="card-widget card-info">
 	 <div class="card-info-avatar is-center">
 	     <div class="avatar-img">
-	         <img data-lazy-src="<?php $this->options->logoUrl() ?>" onerror="this.onerror=null;this.src='<?php $this->options->themeUrl('img/friend_404.gif'); ?>'" src="<?php echo GetLazyLoad() ?>" alt="avatar">
+             <img data-lazy-src="<?php echo getAuthorAvatarUrl(); ?>" onerror="this.onerror=null;this.src='<?php $this->options->themeUrl('img/friend_404.gif'); ?>'" src="<?php echo GetLazyLoad() ?>" alt="avatar">
 	      </div>
 		<div class="author-info__name">
 			<?php $this->author(); ?>


### PR DESCRIPTION
## 背景与目的 (Context & Motivation)
当前主题的作者头像仅支持填写自定义图片 URL。为了提升用户体验并与评论区头像逻辑保持一致，本次 PR 引入了原生的 Gravatar 支持，并对国内常见的 QQ 邮箱做了特殊适配（自动调用 QQ 头像）。

## 改动详情 (Changes)
1. **后台设置项扩展 (`config/custom_config.php`)**
   - 新增 `LogoAvatarMode`（作者头像模式）单选框，支持在“自定义URL”和“使用Gravatar”之间切换。
   - 新增 `authorGravatarEmail` 输入框，用于独立设置作者的 Gravatar 邮箱。

2. **核心逻辑封装 (`functions.php`)**
   - 新增全局函数 `getAuthorAvatarUrl()`。
   - 实现动态判断逻辑：如果选择 Gravatar 模式并填写了邮箱，将自动进行 MD5 加密。
   - **QQ邮箱兼容**：通过正则匹配，若检测到 QQ 邮箱，则强制调用 `cravatar.cn` 源以正确显示 QQ 头像；若是普通邮箱，则跟随主题原有的 `$options->GravatarSelect` CDN 设置。
   - 头像尺寸默认加上 `?s=200` 参数，确保侧边栏展示足够清晰。

3. **前端模板更新**
   - 修改了 `includes/header_com.php` 和 `includes/sidebar.php`。
   - 将原有硬编码的 `$this->options->logoUrl()` 统一替换为 `getAuthorAvatarUrl()` 方法。

## 兼容性说明 (Compatibility)
本次更新完全向下兼容。当用户未切换为 Gravatar 模式或未填写邮箱时，系统会自动 fallback 到原有逻辑，继续输出自定义图片 URL，不影响老用户的现有配置。